### PR TITLE
Configure for Calva (and Gitpod)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 .clj-kondo/.cache/
 .shadow-cljs/
 resources/public/js/
+node_modules/

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,3 @@
+FROM gitpod/workspace-full
+
+RUN brew install clojure/tools/clojure

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,7 +3,7 @@ image:
 
 ports:
   - port: 9631
-    onOpen: open-preview
+    onOpen: open-browser
   - port: 8000
     onOpen: open-preview
 
@@ -14,3 +14,4 @@ vscode:
 tasks:
   - name: Prepare deps
     init: clojure -P -Sdeps '{:deps {nrepl/nrepl {:mvn/version,"0.8.3"},cider/cider-nrepl {:mvn/version,"0.26.0"}}}'
+  - init: npm i

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,16 @@
+image:
+  file: .gitpod.Dockerfile
+
+ports:
+  - port: 9631
+    onOpen: open-preview
+  - port: 8000
+    onOpen: open-preview
+
+vscode:
+  extensions:
+    - betterthantomorrow.calva
+
+tasks:
+  - name: Prepare deps
+    init: clojure -P -Sdeps '{:deps {nrepl/nrepl {:mvn/version,"0.8.3"},cider/cider-nrepl {:mvn/version,"0.26.0"}}}'

--- a/deps.edn
+++ b/deps.edn
@@ -21,6 +21,8 @@
   ;; Activate if you want to `M-x cider-connect-cljs` from Emacs:
   :cider {:extra-deps {cider/cider-nrepl {:mvn/version "0.25.9"}           ; must be added for M-x cider-connect-cljs
                        cider/piggieback {:mvn/version "0.5.1"}}}
+  :shadow-cljs {:extra-deps {thheller/shadow-cljs                {:mvn/version "2.14.5"}
+                             binaryage/devtools                  {:mvn/version "1.0.0"}}}
   
 ;;   :run-m {:main-opts ["-m" "cz.holyjak.minimalist-fulcro-template-backendless"]}
 ;;   :run-x {:ns-default cz.holyjak.minimalist-fulcro-template-backendless

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,54 @@
+{
+  "name": "minimalist-fulcro-template-backendless",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "react-dom": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
+      }
+    },
+    "scheduler": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
   "dependencies": {
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
+  },
+  "devDependencies": {
+    "shadow-cljs": "^2.14.5"
   }
 }

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,4 +1,4 @@
-{:deps     {:aliases []}
+{:deps     {:aliases [:shadow-cljs]}
  :http     {:port 9631} ; shadow control server
  :nrepl    {:port 9001}
  :dev-http {8000 "resources/public"}


### PR DESCRIPTION
I've added Gitpod configuration so that the project can be opened with full Calva editing in the browser by using this link:

https://gitpod.io/#https://github.com/holyjak/minimalist-fulcro-template-backendless

(The repo link prepended by `https://gitpod.io/#`)

Shadow complained that it was not installed in the project properly so I've added it to `devDependencies` in `package.json`.

Then I also added a `:shadow-cljs` alias to `deps.edn` that only adds the shadow dependency. And made `shadow-cljs.edn` include this alias when it starts `clojure`.

Now the Calva instructions for convenient running of this project is to use the Jack-in command and select `shadow-cljs` project type, then to start the `:main` build, and then to connect to it once the app is running in the browser.

If you run this project in Gitpod `npm i` will be run automatically on workspace creation so a full instruction is something like:

1. Open https://gitpod.io/#https://github.com/holyjak/minimalist-fulcro-template-backendless
    * Temporrary? note: Use this link to try it w/o merging the PR https://gitpod.io/#https://github.com/PEZ/minimalist-fulcro-template-backendless
    * It can take a few minutes for the environment to be created and started
2. When the workspace is started you see VS Code running in the browser with the project ready
3. Use the nREPL button in the status bar or the command palette to issue the command **Start a Project REPL and Connect (aka Jack-i)**.
    1. Select project type `:shadow-cljs`
    2. Select to start build `:main`
    3. Wait while shadow-cljs and clojure starts
    4. Selet to connect to build `:main`

When it's done you should see something like this (You might need to reload the Preview browser with the Fulcro app in order for it to start.):

<img width="1354" alt="image" src="https://user-images.githubusercontent.com/30010/131570683-c8ba8aef-c26b-487c-8005-96ff105f8a9c.png">

The second browser tab there is the shadow-cljs server console for your app, with inspector and goodies.