### PR TITLE
feat(pathom): Add pathom placeholder reader

### DIFF
--- a/src/com/example/pathom.cljs
+++ b/src/com/example/pathom.cljs
@@ -1,12 +1,12 @@
 (ns com.example.pathom
   "The Pathom parser that is our (in-browser) backend.
-   
+
    Add your resolvers and 'server-side' mutations here."
   (:require
-    [com.wsscode.pathom.core :as p]
-    [com.wsscode.pathom.connect :as pc]))
+   [com.wsscode.pathom.core :as p]
+   [com.wsscode.pathom.connect :as pc]))
 
-(pc/defresolver index-explorer 
+(pc/defresolver index-explorer
   "This resolver is necessary to make it possible to use 'Load index' in Fulcro Inspect - EQL"
   [env _]
   {::pc/input  #{:com.wsscode.pathom.viz.index-explorer/id}
@@ -16,7 +16,7 @@
        (update ::pc/index-resolvers #(into {} (map (fn [[k v]] [k (dissoc v ::pc/resolve)])) %))
        (update ::pc/index-mutations #(into {} (map (fn [[k v]] [k (dissoc v ::pc/mutate)])) %)))})
 
-(pc/defresolver i-fail 
+(pc/defresolver i-fail
   [_ _]
   {::pc/input  #{}
    ::pc/output [:i-fail]}
@@ -39,20 +39,22 @@
   (println "SERVER: Simulate creating a new thing with real DB id 123" tmpid)
   {:tempids {tmpid 123}})
 
-(def my-resolvers-and-mutations 
+(def my-resolvers-and-mutations
   "Add any resolvers you make to this list (and reload to re-create the parser)"
   [index-explorer create-random-thing i-fail person])
 
-(defn new-parser 
+(defn new-parser
   "Create a new Pathom parser with the necessary settings"
   []
   (p/parallel-parser
-    {::p/env     {::p/reader [p/map-reader
-                              pc/parallel-reader
-                              pc/open-ident-reader]
-                  ::pc/mutation-join-globals [:tempids]}
-     ::p/mutate  pc/mutate-async
-     ::p/plugins [(pc/connect-plugin {::pc/register my-resolvers-and-mutations})
-                  p/error-handler-plugin
-                  p/request-cache-plugin
-                  (p/post-process-parser-plugin p/elide-not-found)]}))
+   {::p/env     {::p/reader [p/map-reader
+                             p/env-placeholder-reader
+                             pc/parallel-reader
+                             pc/open-ident-reader]
+                 ::pc/mutation-join-globals [:tempids]
+                 ::p/placeholder-prefixes #{">"}}
+    ::p/mutate  pc/mutate-async
+    ::p/plugins [(pc/connect-plugin {::pc/register my-resolvers-and-mutations})
+                 p/error-handler-plugin
+                 p/request-cache-plugin
+                 (p/post-process-parser-plugin p/elide-not-found)]}))


### PR DESCRIPTION
This adds `p/env-placeholder-reader` to the `::p/reader` array in the
parser `::p/env`.

We also add `::p/placeholder-prefixes #{">"}` to the env to signify what
symbol we want as a pathom placeholder

![dank](https://media2.giphy.com/media/U634xW7LKU0sU/giphy.gif?cid=74e95743nlukylad3an7rr8tp6za5n144vehdfr2a3qfhsjh&rid=giphy.gif&ct=g)